### PR TITLE
Add named NIRCam Small Grid Dither patterns

### DIFF
--- a/pandeia_coronagraphy/engine.py
+++ b/pandeia_coronagraphy/engine.py
@@ -1,7 +1,14 @@
 from copy import deepcopy
 import json
 import multiprocessing as mp
-from functools32 import lru_cache
+import sys
+
+
+if sys.version_info > (3, 2):
+    from functools import lru_cache
+else:
+    from functools32 import lru_cache
+
 
 import pandeia
 from pandeia.engine.instrument_factory import InstrumentFactory


### PR DESCRIPTION
The NIRCam team implemented several SGD patterns instead of the 3x3 grid.  See [the JDox page on NIRCam SGD](https://jwst-docs.stsci.edu/display/JTI/NIRCam+Small+Grid+Dithers), or [an updated version of that page on the JDox staging server](https://jwst-docs-stage.stsci.edu/display/JTI/NIRCam+Small-Grid+Dithers) which adds the below figure I made last week. 

This PR adds to the `create_SGD` function an option to choose one of these patterns:
``` python
sgds = scene.create_SGD(reference, pattern_name='9-POINT-CIRCLE')
```


Incidentally the PR also fixes the import of the `lru_cache` to work on Python 3.2+ as well as on 2.7. 

![nircam_coron_sgd_v2](https://cloud.githubusercontent.com/assets/1151745/26432187/ecd3e018-40c7-11e7-96fe-15a68c5c9c8c.png)
