### PR TITLE
fix 9-POINT-CIRCLE pointings

### DIFF
--- a/pandeia_coronagraphy/scene.py
+++ b/pandeia_coronagraphy/scene.py
@@ -48,7 +48,7 @@ def create_SGD(calcfile,stepsize=20.e-3, pattern_name=None):
                          ( 0.000, -0.02),
                          ( 0.015, -0.015),
                          ( 0.020,  0.0),
-                         ( 0.015, -0.015)]
+                         ( 0.015,  0.015)]
         elif pattern_name == "3-POINT-BAR":
             pointings = [(0,0),
                          (0.0,  0.015),


### PR DESCRIPTION
@bhilbert4 caught a transcription error in the definition of the NIRCam '9-POINT-CIRCLE' SGD pointings, which is corrected here.

By comparison to the page on [JDox](https://jwst-docs.stsci.edu/display/JTI/NIRCam+Small-Grid+Dithers), all the other SGD definitions appear to be correct.