### PR TITLE
Small grid dither updates

### DIFF
--- a/pandeia_coronagraphy/scene.py
+++ b/pandeia_coronagraphy/scene.py
@@ -66,11 +66,16 @@ def create_SGD(calcfile,stepsize=20.e-3, pattern_name=None):
         pointings = itertools.product(steps,steps)
     sgds = []
 
-    for sx,sy in pointings:
+    for i, (sx, sy) in enumerate(pointings):
         curcalc = deepcopy(calcfile)
-        errx, erry = get_fsm_error()
-        curcalc['scene'][0]['position']['x_offset'] = sx + errx
-        curcalc['scene'][0]['position']['y_offset'] = sy + erry
+        if i > 0:
+            errx, erry = get_fsm_error()
+            offset_x = sx + errx
+            offset_y = sy + erry
+        else:
+            offset_x = sx
+            offset_y = sy
+        offset_scene(curcalc['scene'], offset_x, offset_y)
         sgds.append(curcalc)
     return sgds
 


### PR DESCRIPTION
PR to fix bugs reported by @bhilbert4:

* Small grid dithers now act on all sources in a scene rather than just the target star (modified `scene.create_SGD` to use `scene.offset_scene` for the scene translation)
* Small grid dithers no longer clobber TA offsets (fixed by the change above)
* The fine steering mirror pointing error is no longer added to the (0, 0) element of the SGD pointings. I'm not sure this is strictly correct, but presumably the first pointing of the SGD should only have TA error, while all the subsequent pointings should only have FSM errors. (I also assume the FSM errors don't accumulate, but maybe they should.) These differences are probably minor, but I don't know the best resource to address these questions. Maybe @mperrin has thoughts?